### PR TITLE
add support for more media players

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@
 依赖
 ----
 
--  `mpg123 <http://www.mpg123.de>`__
+-  `mpg123 <http://www.mpg123.de>`__ (如果安装了 `mpv <http://mpv.io>`__ 或 `mplayer <http://mplayerhq.hu>`__ 亦会自动使用)
 -  `requests <https://github.com/kennethreitz/requests>`__
 -  `urwid <http://urwid.org>`__
 


### PR DESCRIPTION
能够支持更多的播放器 (此提交中仅添加了 mpv 和 mplayer). 没有影响到原有的 mpg123 逻辑, 对于仅安装了 mpg123 的用户依然会调用正常播放.

对我来说, 我不想直接用 mpg123 的主要原因是它的输出后端选择只能通过命令行, 这样我想使用 pulseaudio/jack 后端时, 总是需要修改调用的代码. mpv 和 mplayer 等播放器有完整的配置文件支持 :)
