### PR TITLE
redirect stdin to avoid keyboard being captured by player

### DIFF
--- a/pyfm/player.py
+++ b/pyfm/player.py
@@ -35,7 +35,8 @@ class Player(object):
         # using mpg123 to play the track
         # -q(quiet) remove the output to stdout
         self.player_process = subprocess.Popen(
-            self.external_player + [self.current_song.url])
+            self.external_player + [self.current_song.url],
+            stdin=subprocess.PIPE)
         self.is_playing = True
 
     def stop(self):


### PR DESCRIPTION
避免播放器抢走 pyfm 的 stdin. 增加这个修改后, mpv 和 mplayer 也与 mpg123 有完全相同的表现了.
