### PR TITLE
针对linux系统桌面通知正确显示歌曲图片

### DIFF
--- a/pyfm/notifier.py
+++ b/pyfm/notifier.py
@@ -112,6 +112,9 @@ class Notifier(object):
             stderr=subprocess.STDOUT
         )
 
+        import time
+        time.sleep(0.5)
+
         subprocess.Popen([
             self.bin_path,
             '-i',


### PR DESCRIPTION
curl图片子进程和notify-send两个子进程之间需要短暂sleep。

ps: ubuntu14.04下mplayer播放歌曲时主页面会报错：
mplayer: 
could not connect to socket mplayer: 
No such file or directory
需要在/etc/mplayer/mplayer.conf下面增加一行“lirc=no”。
